### PR TITLE
Add priority lock for CheckTx in mempool and ReCheck ABCI interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.25.1
+
+*October 17, 2018*
+
+BUG FIXES:
+
+- [state] [\#2616](https://github.com/tendermint/tendermint/issues/2616) Fix panic when genesis file's `validators` field is nil
+- [consensus] [\#2634](https://github.com/tendermint/tendermint/issues/2634) Set `NextValidators` during replay
+
 ## v0.25.0
 
 *September 22, 2018*
@@ -164,8 +173,8 @@ BUG FIXES:
 *August 22nd, 2018*
 
 BUG FIXES:
-- [libs/autofile] \#2261 Fix log rotation so it actually happens.
-    - Fixes issues with consensus WAL growing unbounded ala \#2259
+- [libs/autofile] [\#2261](https://github.com/tendermint/tendermint/issues/2261) Fix log rotation so it actually happens.
+    - Fixes issues with consensus WAL growing unbounded ala [\#2259](https://github.com/tendermint/tendermint/issues/2259)
 
 ## 0.23.0
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,5 +15,3 @@ FEATURES:
 IMPROVEMENTS:
 
 BUG FIXES:
-- \#2616 Pass nil to NewValidatorSet() when genesis file's Validators field is nil
-- \#2634 Set next validators along with validators while replay

--- a/abci/client/client.go
+++ b/abci/client/client.go
@@ -30,6 +30,7 @@ type Client interface {
 	SetOptionAsync(types.RequestSetOption) *ReqRes
 	DeliverTxAsync(tx []byte) *ReqRes
 	CheckTxAsync(tx []byte) *ReqRes
+	ReCheckTxAsync(tx []byte) *ReqRes
 	QueryAsync(types.RequestQuery) *ReqRes
 	CommitAsync() *ReqRes
 	InitChainAsync(types.RequestInitChain) *ReqRes

--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -177,6 +177,15 @@ func (cli *grpcClient) CheckTxAsync(tx []byte) *ReqRes {
 	return cli.finishAsyncCall(req, &types.Response{Value: &types.Response_CheckTx{res}})
 }
 
+func (cli *grpcClient) ReCheckTxAsync(tx []byte) *ReqRes {
+	req := types.ToRequestCheckTx(tx)
+	res, err := cli.client.CheckTx(context.Background(), req.GetCheckTx(), grpc.FailFast(true))
+	if err != nil {
+		cli.StopForError(err)
+	}
+	return cli.finishAsyncCall(req, &types.Response{Value: &types.Response_CheckTx{res}})
+}
+
 func (cli *grpcClient) QueryAsync(params types.RequestQuery) *ReqRes {
 	req := types.ToRequestQuery(params)
 	res, err := cli.client.Query(context.Background(), req.GetQuery(), grpc.FailFast(true))

--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -91,6 +91,16 @@ func (app *localClient) CheckTxAsync(tx []byte) *ReqRes {
 	)
 }
 
+func (app *localClient) ReCheckTxAsync(tx []byte) *ReqRes {
+	app.mtx.Lock()
+	res := app.Application.ReCheckTx(tx)
+	app.mtx.Unlock()
+	return app.callback(
+		types.ToRequestCheckTx(tx),
+		types.ToResponseCheckTx(res),
+	)
+}
+
 func (app *localClient) QueryAsync(req types.RequestQuery) *ReqRes {
 	app.mtx.Lock()
 	res := app.Application.Query(req)

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -246,6 +246,10 @@ func (cli *socketClient) CheckTxAsync(tx []byte) *ReqRes {
 	return cli.queueRequest(types.ToRequestCheckTx(tx))
 }
 
+func (cli *socketClient) ReCheckTxAsync(tx []byte) *ReqRes {
+	return cli.queueRequest(types.ToRequestCheckTx(tx))
+}
+
 func (cli *socketClient) QueryAsync(req types.RequestQuery) *ReqRes {
 	return cli.queueRequest(types.ToRequestQuery(req))
 }

--- a/abci/example/kvstore/persistent_kvstore.go
+++ b/abci/example/kvstore/persistent_kvstore.go
@@ -78,6 +78,10 @@ func (app *PersistentKVStoreApplication) CheckTx(tx []byte) types.ResponseCheckT
 	return app.app.CheckTx(tx)
 }
 
+func (app *PersistentKVStoreApplication) ReCheckTx(tx []byte) types.ResponseCheckTx {
+	return app.app.CheckTx(tx)
+}
+
 // Commit will panic if InitChain was not called
 func (app *PersistentKVStoreApplication) Commit() types.ResponseCommit {
 	return app.app.Commit()

--- a/abci/types/application.go
+++ b/abci/types/application.go
@@ -15,7 +15,8 @@ type Application interface {
 	Query(RequestQuery) ResponseQuery             // Query for state
 
 	// Mempool Connection
-	CheckTx(tx []byte) ResponseCheckTx // Validate a tx for the mempool
+	CheckTx(tx []byte) ResponseCheckTx   // Validate a tx for the mempool
+	ReCheckTx(tx []byte) ResponseCheckTx // Validate a tx for the mempool
 
 	// Consensus Connection
 	InitChain(RequestInitChain) ResponseInitChain    // Initialize blockchain with validators and other info from TendermintCore
@@ -50,6 +51,10 @@ func (BaseApplication) DeliverTx(tx []byte) ResponseDeliverTx {
 }
 
 func (BaseApplication) CheckTx(tx []byte) ResponseCheckTx {
+	return ResponseCheckTx{Code: CodeTypeOK}
+}
+
+func (BaseApplication) ReCheckTx(tx []byte) ResponseCheckTx {
 	return ResponseCheckTx{Code: CodeTypeOK}
 }
 

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -95,7 +95,11 @@ func deliverTxsRange(cs *ConsensusState, start, end int) {
 
 func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	state, privVals := randGenesisState(1, false, 10)
-	cs := newConsensusState(state, privVals[0], NewCounterApplication())
+	// checkTx and block mutex are not purely FIFO, so we don't need to stick
+	// to the counter sequence
+	app := NewCounterApplication()
+	app.serial = false
+	cs := newConsensusState(state, privVals[0], app)
 	height, round := cs.Height, cs.Round
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
 
@@ -182,10 +186,11 @@ type CounterApplication struct {
 
 	txCount        int
 	mempoolTxCount int
+	serial         bool
 }
 
 func NewCounterApplication() *CounterApplication {
-	return &CounterApplication{}
+	return &CounterApplication{serial: true}
 }
 
 func (app *CounterApplication) Info(req abci.RequestInfo) abci.ResponseInfo {
@@ -194,7 +199,7 @@ func (app *CounterApplication) Info(req abci.RequestInfo) abci.ResponseInfo {
 
 func (app *CounterApplication) DeliverTx(tx []byte) abci.ResponseDeliverTx {
 	txValue := txAsUint64(tx)
-	if txValue != uint64(app.txCount) {
+	if app.serial && txValue != uint64(app.txCount) {
 		return abci.ResponseDeliverTx{
 			Code: code.CodeTypeBadNonce,
 			Log:  fmt.Sprintf("Invalid nonce. Expected %v, got %v", app.txCount, txValue)}
@@ -205,7 +210,7 @@ func (app *CounterApplication) DeliverTx(tx []byte) abci.ResponseDeliverTx {
 
 func (app *CounterApplication) CheckTx(tx []byte) abci.ResponseCheckTx {
 	txValue := txAsUint64(tx)
-	if txValue != uint64(app.mempoolTxCount) {
+	if app.serial && txValue != uint64(app.mempoolTxCount) {
 		return abci.ResponseCheckTx{
 			Code: code.CodeTypeBadNonce,
 			Log:  fmt.Sprintf("Invalid nonce. Expected %v, got %v", app.mempoolTxCount, txValue)}

--- a/proxy/app_conn.go
+++ b/proxy/app_conn.go
@@ -25,6 +25,7 @@ type AppConnMempool interface {
 	Error() error
 
 	CheckTxAsync(tx []byte) *abcicli.ReqRes
+	ReCheckTxAsync(tx []byte) *abcicli.ReqRes
 
 	FlushAsync() *abcicli.ReqRes
 	FlushSync() error
@@ -112,6 +113,10 @@ func (app *appConnMempool) FlushSync() error {
 
 func (app *appConnMempool) CheckTxAsync(tx []byte) *abcicli.ReqRes {
 	return app.appConn.CheckTxAsync(tx)
+}
+
+func (app *appConnMempool) ReCheckTxAsync(tx []byte) *abcicli.ReqRes {
+	return app.appConn.ReCheckTxAsync(tx)
 }
 
 //------------------------------------------------

--- a/version/version.go
+++ b/version/version.go
@@ -4,13 +4,13 @@ package version
 const (
 	Maj = "0"
 	Min = "25"
-	Fix = "0"
+	Fix = "1"
 )
 
 var (
 	// Version is the current version of Tendermint
 	// Must be a string because scripts like dist.sh read this file.
-	Version = "0.25.0"
+	Version = "0.25.1"
 
 	// GitCommit is the current HEAD set using ldflags.
 	GitCommit string


### PR DESCRIPTION
# Description
1. Add priority lock so that concurrent incoming messages would not stop blocking.
2. Add ReCheck ABCI interface to faciliate lighter CheckTx.

- [x] build passed (make build)
- [x] tests passed (make test)

BiJie/BinanceChain#218