### PR TITLE
Make mempool reactor handles received msg asynchronously

### DIFF
--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -302,7 +302,6 @@ func TestReapPriority(t *testing.T) {
 	//go reapCheck()
 	wg.Add(TotalTx)
 	for i := 1; i <= TotalTx; i++ {
-		fmt.Printf("Insert checkTX:%v\n", i)
 		go checkTxs(i)
 	}
 	//close(seqReap)

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -525,7 +525,13 @@ FOR_LOOP:
 			if msgBytes != nil {
 				c.Logger.Debug("Received bytes", "chID", pkt.ChannelID, "msgBytes", fmt.Sprintf("%X", msgBytes))
 				// NOTE: This means the reactor.Receive runs in the same thread as the p2p recv routine
-				c.onReceive(pkt.ChannelID, msgBytes)
+				// except the mempool actually is using an asynchronus Receive() to prevent jamming requests
+				// stopping block producing (tested via )
+
+				// this copy is due to the underlying memory is shared, and causes problem for async call
+				msgCopy := make([]byte, len(msgBytes))
+				copy(msgCopy, msgBytes)
+				c.onReceive(pkt.ChannelID, msgCopy)
 			}
 		default:
 			err := fmt.Errorf("Unknown message type %v", reflect.TypeOf(packet))


### PR DESCRIPTION
BiJie/BinanceChain#280

# Description

Now all the p2p gossips are sharing the same connections, and the receiving logic has no priority but handle messages in a sequential manner. So that when the requests come in and jam the thread, block parts would be queued long before handling. The blocking latency can increase a lot due to this.

Here mempool reactor is changed to handle the message aysnchronously, so that `CheckTx` would not stop consensus reactor handling on `BlockPartMessage`.

- [x] make build pass
- [x] make test pass

