### PR TITLE
[R4R]support Sentry Node, add simple blockexecutor and  restrictPeers config param#7

### DIFF
--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -36,7 +36,7 @@ func newBlockchainReactor(logger log.Logger, maxBlockHeight int64) *BlockchainRe
 	fastSync := true
 	var nilApp proxy.AppConnConsensus
 	blockExec := sm.NewBlockExecutor(dbm.NewMemDB(), log.TestingLogger(), nilApp,
-		sm.MockMempool{}, sm.MockEvidencePool{})
+		sm.MockMempool{}, sm.MockEvidencePool{}, true)
 
 	bcReactor := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
 	bcReactor.SetLogger(logger.With("module", "blockchain"))

--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,9 @@ type BaseConfig struct {
 	// If true, query the ABCI app on connecting to a new peer
 	// so the app can decide if we should keep the connection or not
 	FilterPeers bool `mapstructure:"filter_peers"` // false
+
+	// Whether application get state
+	WithAppStat bool `mapstructure:"with_app_stat"`
 }
 
 // DefaultBaseConfig returns a default base configuration for a Tendermint node
@@ -161,6 +164,7 @@ func DefaultBaseConfig() BaseConfig {
 		FilterPeers:       false,
 		DBBackend:         "leveldb",
 		DBPath:            "data",
+		WithAppStat:       true,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -111,6 +111,9 @@ prof_laddr = "{{ .BaseConfig.ProfListenAddress }}"
 # so the app can decide if we should keep the connection or not
 filter_peers = {{ .BaseConfig.FilterPeers }}
 
+# If false, will not check appHash when apply block
+with_app_stat = {{ .BaseConfig.WithAppStat }}
+
 ##### advanced configuration options #####
 
 ##### rpc server configuration options #####

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -267,7 +267,7 @@ func newConsensusStateWithConfigAndBlockStore(thisConfig *cfg.Config, state sm.S
 
 	// Make ConsensusState
 	stateDB := dbm.NewMemDB()
-	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyAppConnCon, mempool, evpool, true)
 	cs := NewConsensusState(thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool)
 	cs.SetLogger(log.TestingLogger().With("module", "consensus"))
 	cs.SetPrivValidator(pv)

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -143,7 +143,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		evpool := newMockEvidencePool(privVals[vIdx].GetAddress())
 
 		// Make ConsensusState
-		blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
+		blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyAppConnCon, mempool, evpool, true)
 		cs := NewConsensusState(thisConfig.Consensus, state, blockExec, blockStore, mempool, evpool)
 		cs.SetLogger(log.TestingLogger().With("module", "consensus"))
 		cs.SetPrivValidator(pv)

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -199,11 +199,12 @@ type Handshaker struct {
 	genDoc       *types.GenesisDoc
 	logger       log.Logger
 
-	nBlocks int // number of blocks applied to the state
+	withAppStat bool
+	nBlocks     int // number of blocks applied to the state
 }
 
 func NewHandshaker(stateDB dbm.DB, state sm.State,
-	store sm.BlockStore, genDoc *types.GenesisDoc) *Handshaker {
+	store sm.BlockStore, genDoc *types.GenesisDoc, withAppStat bool) *Handshaker {
 
 	return &Handshaker{
 		stateDB:      stateDB,
@@ -212,6 +213,7 @@ func NewHandshaker(stateDB dbm.DB, state sm.State,
 		genDoc:       genDoc,
 		logger:       log.NewNopLogger(),
 		nBlocks:      0,
+		withAppStat:  withAppStat,
 	}
 }
 
@@ -407,7 +409,7 @@ func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.Ap
 	block := h.store.LoadBlock(height)
 	meta := h.store.LoadBlockMeta(height)
 
-	blockExec := sm.NewBlockExecutor(h.stateDB, h.logger, proxyApp, sm.MockMempool{}, sm.MockEvidencePool{})
+	blockExec := sm.NewBlockExecutor(h.stateDB, h.logger, proxyApp, sm.MockMempool{}, sm.MockEvidencePool{}, h.withAppStat)
 
 	var err error
 	state, err = blockExec.ApplyBlock(state, meta.BlockID, block)

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -304,7 +304,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 		cmn.Exit(fmt.Sprintf("Error starting proxy app conns: %v", err))
 	}
 
-	handshaker := NewHandshaker(stateDB, state, blockStore, gdoc)
+	handshaker := NewHandshaker(stateDB, state, blockStore, gdoc, true)
 	err = handshaker.Handshake(proxyApp)
 	if err != nil {
 		cmn.Exit(fmt.Sprintf("Error on handshake: %v", err))
@@ -316,7 +316,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 	}
 
 	mempool, evpool := sm.MockMempool{}, sm.MockEvidencePool{}
-	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, true)
 
 	consensusState := NewConsensusState(csConfig, state.Copy(), blockExec,
 		blockStore, mempool, evpool)

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -358,7 +358,7 @@ func testHandshakeReplay(t *testing.T, nBlocks int, mode uint) {
 
 	// now start the app using the handshake - it should sync
 	genDoc, _ := sm.MakeGenesisDocFromFile(config.GenesisFile())
-	handshaker := NewHandshaker(stateDB, state, store, genDoc)
+	handshaker := NewHandshaker(stateDB, state, store, genDoc, true)
 	proxyApp := proxy.NewAppConns(clientCreator2)
 	if err := proxyApp.Start(); err != nil {
 		t.Fatalf("Error starting proxy app connections: %v", err)
@@ -393,7 +393,7 @@ func testHandshakeReplay(t *testing.T, nBlocks int, mode uint) {
 
 func applyBlock(stateDB dbm.DB, st sm.State, blk *types.Block, proxyApp proxy.AppConns) sm.State {
 	testPartSize := types.BlockPartSizeBytes
-	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, true)
 
 	blkID := types.BlockID{blk.Hash(), blk.MakePartSet(testPartSize).Header()}
 	newState, err := blockExec.ApplyBlock(st, blkID, blk)
@@ -645,7 +645,7 @@ func TestInitChainUpdateValidators(t *testing.T) {
 
 	// now start the app using the handshake - it should sync
 	genDoc, _ := sm.MakeGenesisDocFromFile(config.GenesisFile())
-	handshaker := NewHandshaker(stateDB, state, store, genDoc)
+	handshaker := NewHandshaker(stateDB, state, store, genDoc, true)
 	proxyApp := proxy.NewAppConns(clientCreator)
 	if err := proxyApp.Start(); err != nil {
 		t.Fatalf("Error starting proxy app connections: %v", err)

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -67,7 +67,7 @@ func WALWithNBlocks(numBlocks int) (data []byte, err error) {
 	defer eventBus.Stop()
 	mempool := sm.MockMempool{}
 	evpool := sm.MockEvidencePool{}
-	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
+	blockExec := sm.NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool, true)
 	consensusState := NewConsensusState(config.Consensus, state.Copy(), blockExec, blockStore, mempool, evpool)
 	consensusState.SetLogger(logger)
 	consensusState.SetEventBus(eventBus)

--- a/node/node.go
+++ b/node/node.go
@@ -198,7 +198,7 @@ func NewNode(config *cfg.Config,
 	// Create the handshaker, which calls RequestInfo and replays any blocks
 	// as necessary to sync tendermint with the app.
 	consensusLogger := logger.With("module", "consensus")
-	handshaker := cs.NewHandshaker(stateDB, state, blockStore, genDoc)
+	handshaker := cs.NewHandshaker(stateDB, state, blockStore, genDoc, config.WithAppStat)
 	handshaker.SetLogger(consensusLogger)
 	if err := handshaker.Handshake(proxyApp); err != nil {
 		return nil, fmt.Errorf("Error during handshake: %v", err)
@@ -289,7 +289,7 @@ func NewNode(config *cfg.Config,
 
 	blockExecLogger := logger.With("module", "state")
 	// make block executor for consensus and blockchain reactors to execute blocks
-	blockExec := sm.NewBlockExecutor(stateDB, blockExecLogger, proxyApp.Consensus(), mempool, evidencePool)
+	blockExec := sm.NewBlockExecutor(stateDB, blockExecLogger, proxyApp.Consensus(), mempool, evidencePool, config.WithAppStat)
 
 	// Make BlockchainReactor
 	bcReactor := bc.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)

--- a/state/execution.go
+++ b/state/execution.go
@@ -33,19 +33,23 @@ type BlockExecutor struct {
 	evpool  EvidencePool
 
 	logger log.Logger
+
+	// whether to check appHash
+	withAppState bool
 }
 
 // NewBlockExecutor returns a new BlockExecutor with a NopEventBus.
 // Call SetEventBus to provide one.
 func NewBlockExecutor(db dbm.DB, logger log.Logger, proxyApp proxy.AppConnConsensus,
-	mempool Mempool, evpool EvidencePool) *BlockExecutor {
+	mempool Mempool, evpool EvidencePool, withAppState bool) *BlockExecutor {
 	return &BlockExecutor{
-		db:       db,
-		proxyApp: proxyApp,
-		eventBus: types.NopEventBus{},
-		mempool:  mempool,
-		evpool:   evpool,
-		logger:   logger,
+		db:           db,
+		proxyApp:     proxyApp,
+		eventBus:     types.NopEventBus{},
+		mempool:      mempool,
+		evpool:       evpool,
+		logger:       logger,
+		withAppState: withAppState,
 	}
 }
 
@@ -60,7 +64,7 @@ func (blockExec *BlockExecutor) SetEventBus(eventBus types.BlockEventPublisher) 
 // Validation does not mutate state, but does require historical information from the stateDB,
 // ie. to verify evidence from a validator at an old height.
 func (blockExec *BlockExecutor) ValidateBlock(state State, block *types.Block) error {
-	return validateBlock(blockExec.db, state, block)
+	return validateBlock(blockExec.db, state, block, blockExec.withAppState)
 }
 
 // ApplyBlock validates the block against the state, executes it against the app,

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -37,7 +37,7 @@ func TestApplyBlock(t *testing.T) {
 	state, stateDB := state(1, 1)
 
 	blockExec := NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(),
-		MockMempool{}, MockEvidencePool{})
+		MockMempool{}, MockEvidencePool{}, true)
 
 	block := makeBlock(state, 1)
 	blockID := types.BlockID{block.Hash(), block.MakePartSet(testPartSize).Header()}
@@ -247,7 +247,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 	state, stateDB := state(1, 1)
 
 	blockExec := NewBlockExecutor(stateDB, log.TestingLogger(), proxyApp.Consensus(),
-		MockMempool{}, MockEvidencePool{})
+		MockMempool{}, MockEvidencePool{}, true)
 	eventBus := types.NewEventBus()
 	err = eventBus.Start()
 	require.NoError(t, err)

--- a/state/validation.go
+++ b/state/validation.go
@@ -13,7 +13,7 @@ import (
 //-----------------------------------------------------
 // Validate block
 
-func validateBlock(stateDB dbm.DB, state State, block *types.Block) error {
+func validateBlock(stateDB dbm.DB, state State, block *types.Block, withAppStat bool) error {
 	// Validate internal consistency.
 	if err := block.ValidateBasic(); err != nil {
 		return err
@@ -53,7 +53,7 @@ func validateBlock(stateDB dbm.DB, state State, block *types.Block) error {
 	}
 
 	// Validate app info
-	if !bytes.Equal(block.AppHash, state.AppHash) {
+	if withAppStat && !bytes.Equal(block.AppHash, state.AppHash) {
 		return fmt.Errorf(
 			"Wrong Block.Header.AppHash.  Expected %X, got %v",
 			state.AppHash,
@@ -67,7 +67,7 @@ func validateBlock(stateDB dbm.DB, state State, block *types.Block) error {
 			block.ConsensusHash,
 		)
 	}
-	if !bytes.Equal(block.LastResultsHash, state.LastResultsHash) {
+	if withAppStat && !bytes.Equal(block.LastResultsHash, state.LastResultsHash) {
 		return fmt.Errorf(
 			"Wrong Block.Header.LastResultsHash.  Expected %X, got %v",
 			state.LastResultsHash,

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -12,7 +12,7 @@ import (
 func TestValidateBlock(t *testing.T) {
 	state, _ := state(1, 1)
 
-	blockExec := NewBlockExecutor(dbm.NewMemDB(), log.TestingLogger(), nil, nil, nil)
+	blockExec := NewBlockExecutor(dbm.NewMemDB(), log.TestingLogger(), nil, nil, nil, true)
 
 	// proper block must pass
 	block := makeBlock(state, 1)


### PR DESCRIPTION
To support sentry node that only sync block from trusted node without varyfy and consensus.
We add more config to control  block reactor.
1. add a simple block executor.
2. add peer_restrict configure param
3. modified test file to make ut pass
4. add executor_type configure param
* [x] build pass
* [x] test pass
