### PR TITLE
[AR4R] fix p2p reconnection failed

### DIFF
--- a/blockchain/pool.go
+++ b/blockchain/pool.go
@@ -256,7 +256,7 @@ func (pool *BlockPool) AddBlock(peerID p2p.ID, block *types.Block, blockSize int
 		}
 	} else {
 		pool.Logger.Info("invalid peer", "peer", peerID, "blockHeight", block.Height)
-		pool.sendError(errors.New("invalid peer"), peerID)
+		//pool.sendError(errors.New("invalid peer"), peerID)
 	}
 }
 

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -272,3 +272,5 @@ func (br *ByzantineReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 func (br *ByzantineReactor) Receive(chID byte, peer p2p.Peer, msgBytes []byte) {
 	br.reactor.Receive(chID, peer, msgBytes)
 }
+
+func (br *ByzantineReactor) InitAddPeer(peer p2p.Peer) p2p.Peer { return peer }

--- a/p2p/base_reactor.go
+++ b/p2p/base_reactor.go
@@ -17,6 +17,9 @@ type Reactor interface {
 	// AddPeer is called by the switch when a new peer is added.
 	AddPeer(peer Peer)
 
+	// InitAddPeer is called by switch before peer is started.
+	InitAddPeer(peer Peer) Peer
+
 	// RemovePeer is called by the switch when the peer is stopped (due to error
 	// or other reason).
 	RemovePeer(peer Peer, reason interface{})
@@ -51,3 +54,4 @@ func (*BaseReactor) GetChannels() []*conn.ChannelDescriptor        { return nil 
 func (*BaseReactor) AddPeer(peer Peer)                             {}
 func (*BaseReactor) RemovePeer(peer Peer, reason interface{})      {}
 func (*BaseReactor) Receive(chID byte, peer Peer, msgBytes []byte) {}
+func (*BaseReactor) InitAddPeer(peer Peer) Peer                    { return peer }

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -216,7 +216,7 @@ func (r *PEXReactor) Receive(chID byte, src Peer, msgBytes []byte) {
 
 		// If we're a seed and this is an inbound peer,
 		// respond once and disconnect.
-		if r.config.SeedMode && !src.IsOutbound() {
+		if r.config.SeedMode && !r.Switch.IsPersistent(src) {
 			id := string(src.ID())
 			v := r.lastReceivedRequests.Get(id)
 			if v != nil {
@@ -228,6 +228,7 @@ func (r *PEXReactor) Receive(chID byte, src Peer, msgBytes []byte) {
 
 			// Send addrs and disconnect
 			r.SendAddrs(src, r.book.GetSelectionWithBias(biasToSelectNewPeers))
+
 			go func() {
 				// In a go-routine so it doesn't block .Receive.
 				src.FlushStop()
@@ -666,7 +667,7 @@ func (r *PEXReactor) attemptDisconnects() {
 		if peer.Status().Duration < defaultSeedDisconnectWaitPeriod {
 			continue
 		}
-		if peer.IsPersistent() {
+		if r.Switch.IsPersistent(peer) {
 			continue
 		}
 		r.Switch.StopPeerGracefully(peer)


### PR DESCRIPTION
### Description

Fix Seed node reconnection to data-seed failed.


### Rationale
Concreate analise: https://github.com/binance-chain/bnc-tendermint/issues/37

1、peerSet contains dirty data.
2、seed will disconnect persistent peers, since persistent peer may become incoming peer after.

And one thing notice:  
blockchain/pool.go when fastsync and block response is later than 15s, will stop the peer. 
For peer we get pongtimeout(also 15s) to check network connectivity. If disconnect the peer, most of other sync block will dropped, cause more latency.

### Example

### Changes
Function peer.IsPersistent not use anymore

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

