### PR TITLE
[R4R]fix pool timer leak bug

### DIFF
--- a/blockchain/pool.go
+++ b/blockchain/pool.go
@@ -299,6 +299,9 @@ func (pool *BlockPool) removePeer(peerID p2p.ID) {
 			requester.redo(peerID)
 		}
 	}
+	if p, exist := pool.peers[peerID]; exist && p.timeout != nil {
+		p.timeout.Stop()
+	}
 	delete(pool.peers, peerID)
 }
 


### PR DESCRIPTION
### Description
timer leak in bpPeer which cause peer reconnection every 15 s when in fastsync mode

### Rationale
The bpPeer get timer:
```
func (peer *bpPeer) resetTimeout() {
	if peer.timeout == nil {
		peer.timeout = time.AfterFunc(peerTimeout, peer.onTimeout)
	} else {
		peer.timeout.Reset(peerTimeout)
	}
}
```
the AfterFunc will `startTimer`, even this timer is set to nil, the func will still execute:
```
func AfterFunc(d Duration, f func()) *Timer {
	t := &Timer{
		r: runtimeTimer{
			when: when(d),
			f:    goFunc,
			arg:  f,
		},
	}
	startTimer(&t.r)
	return t
}
```
When remove peer, block pool simple remove bpPeer, but do not stop timer, that cause stopError for correct peer.

Before and after fix, the reconnect won't happen again:
![image](https://user-images.githubusercontent.com/7310198/53138601-e3e66c00-35c1-11e9-9853-205d4f241013.png)


### Example

### Changes

Notable changes: 
Just stop timer when remove peer.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [] integration tests passed (`make integration_test`)
- [] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

