### PR TITLE
[R4R]close flushTimer twice

### DIFF
--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -212,6 +212,12 @@ func (c *MConnection) OnStart() error {
 // the connection.
 // NOTE: it is not safe to call this method more than once.
 func (c *MConnection) FlushStop() {
+	select {
+	case <-c.quitSendRoutine:
+		// already quit via OnStop
+		return
+	default:
+	}
 	c.BaseService.OnStop()
 	c.flushTimer.Stop()
 	c.pingTimer.Stop()


### PR DESCRIPTION
### Description
I get log in seed:

```
panic: close of closed channel

goroutine 8133080 [running]:
github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/libs/common.(*ThrottleTimer).Stop(0xc0045cb980, 0xc00aca7200)
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/libs/common/throttle_timer.go:71 +0x41
github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/p2p/conn.(*MConnection).FlushStop(0xc0042897c0)
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/p2p/conn/connection.go:216 +0x36
github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/p2p.(*peer).FlushStop(0xc006d2bc80)
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/p2p/peer.go:193 +0x44
github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/p2p/pex.(*PEXReactor).Receive.func1(0x12d6500, 0xc006d2bc80, 0xc0000bc240)
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/p2p/pex/pex_reactor.go:234 +0x31
created by github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/p2p/pex.(*PEXReactor).Receive
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/p2p/pex/pex_reactor.go:232 +0x87e
panic: close of closed channel
```
### Rationale

Seed is running in seed mode, when it receive a `pexRequestMessage` and the peer is not persistent, it will:
```
src.FlushStop()
r.Switch.StopPeerGracefully(src)
```
But if other reactor called `StopPeerForError`,  since `FlushStop` is not an interface of `BaseService`, it may happend with`mconnection.OnStopn()` at the same time, which will cause panic.


### Example

### Changes



### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [] integration tests passed (`make integration_test`)
- [] manual transaction test passed (cli invoke)

### Already reviewed by


### Related issues

... reference related issue #'s here ...

