### PR TITLE
[R4R]make lite abci query availble

### DIFF
--- a/cmd/tendermint/commands/lite.go
+++ b/cmd/tendermint/commands/lite.go
@@ -43,7 +43,7 @@ func init() {
 	LiteCmd.Flags().IntVar(&cacheSize, "cache-size", 10, "Specify the memory trust store cache size")
 }
 
-func ensureAddrHasSchemeOrDefaultToTCP(addr string) (string, error) {
+func EnsureAddrHasSchemeOrDefaultToTCP(addr string) (string, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
 		return "", err
@@ -59,11 +59,11 @@ func ensureAddrHasSchemeOrDefaultToTCP(addr string) (string, error) {
 }
 
 func runProxy(cmd *cobra.Command, args []string) error {
-	nodeAddr, err := ensureAddrHasSchemeOrDefaultToTCP(nodeAddr)
+	nodeAddr, err := EnsureAddrHasSchemeOrDefaultToTCP(nodeAddr)
 	if err != nil {
 		return err
 	}
-	listenAddr, err := ensureAddrHasSchemeOrDefaultToTCP(listenAddr)
+	listenAddr, err := EnsureAddrHasSchemeOrDefaultToTCP(listenAddr)
 	if err != nil {
 		return err
 	}

--- a/lite/proxy/proxy.go
+++ b/lite/proxy/proxy.go
@@ -66,7 +66,7 @@ func RPCRoutes(c rpcclient.Client) map[string]*rpcserver.RPCFunc {
 		"block":      rpcserver.NewRPCFunc(c.Block, "height"),
 		"commit":     rpcserver.NewRPCFunc(c.Commit, "height"),
 		"tx":         rpcserver.NewRPCFunc(c.Tx, "hash,prove"),
-		"validators": rpcserver.NewRPCFunc(c.Validators, ""),
+		"validators": rpcserver.NewRPCFunc(c.Validators, "height"),
 
 		// broadcast API
 		"broadcast_tx_commit": rpcserver.NewRPCFunc(c.BroadcastTxCommit, "tx"),
@@ -74,7 +74,7 @@ func RPCRoutes(c rpcclient.Client) map[string]*rpcserver.RPCFunc {
 		"broadcast_tx_async":  rpcserver.NewRPCFunc(c.BroadcastTxAsync, "tx"),
 
 		// abci API
-		"abci_query": rpcserver.NewRPCFunc(c.ABCIQuery, "path,data,prove"),
+		"abci_query": rpcserver.NewRPCFunc(c.ABCIQuery, "path,data"),
 		"abci_info":  rpcserver.NewRPCFunc(c.ABCIInfo, ""),
 	}
 }

--- a/lite/proxy/wrapper.go
+++ b/lite/proxy/wrapper.go
@@ -145,6 +145,10 @@ func (w Wrapper) Commit(height *int64) (*ctypes.ResultCommit, error) {
 	return res, err
 }
 
+func (w Wrapper) RegisterOpDecoder(typ string, dec merkle.OpDecoder) {
+	w.prt.RegisterOpDecoder(typ, dec)
+}
+
 // // WrappedSwitch creates a websocket connection that auto-verifies any info
 // // coming through before passing it along.
 // //


### PR DESCRIPTION
### Description
The abci_query of current light client is not availble.
### Rationale
The main problem is:
1. `"abci_query": rpcserver.NewRPCFunc(c.ABCIQuery, "path,data,prove")`
  `"validators": rpcserver.NewRPCFunc(c.Validators, "height"),`
 the parameters and function do not match, cause index out of range error.
2.  the `prove` of query is forced to be true, while default option is false. 
3. the key of merkle is wrong

### Example

### Changes



### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [] integration tests passed (`make integration_test`)
- [] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

