### PR TITLE
[R4R]disable compress in rpc client

### DIFF
--- a/rpc/lib/client/http_client.go
+++ b/rpc/lib/client/http_client.go
@@ -74,7 +74,9 @@ func makeHTTPClient(remoteAddr string) (string, *http.Client) {
 	protocol, address, dialer := makeHTTPDialer(remoteAddr)
 	return protocol + "://" + address, &http.Client{
 		Transport: &http.Transport{
-			Dial: dialer,
+			// Set to true to prevent GZIP-bomb DoS attacks
+			DisableCompression: true,
+			Dial:               dialer,
 		},
 	}
 }


### PR DESCRIPTION
### Description
disable compress option to avoid gzip bomb.

both bnbcli and lightd will use go client to request other node. 

mirror pr https://github.com/tendermint/tendermint/pull/3430

### Rationale
![image](https://user-images.githubusercontent.com/7310198/54403885-a2eafe80-470c-11e9-8baf-bca736c3a44d.png)


### Changes

### Preflight checks
As I test bnbcli and lighted. It won't decompression response again, but print binary response.

- [x] build passed (`make build`)
- [x] tests passed (`make test`)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

