### PR TITLE
[R4R]p2p: do not log err if peer is private

### DIFF
--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -677,21 +677,8 @@ func (a *addrBook) addAddress(addr, src *p2p.NetAddress) error {
 		return ErrAddrBookNilAddr{addr, src}
 	}
 
-	if a.routabilityStrict && !addr.Routable() {
-		return ErrAddrBookNonRoutable{addr}
-	}
-
-	if !addr.Valid() {
-		return ErrAddrBookInvalidAddr{addr}
-	}
-
 	if !addr.HasID() {
 		return ErrAddrBookInvalidAddrNoID{addr}
-	}
-
-	// TODO: we should track ourAddrs by ID and by IP:PORT and refuse both.
-	if _, ok := a.ourAddrs[addr.String()]; ok {
-		return ErrAddrBookSelf{addr}
 	}
 
 	if _, ok := a.privateIDs[addr.ID]; ok {
@@ -700,6 +687,19 @@ func (a *addrBook) addAddress(addr, src *p2p.NetAddress) error {
 
 	if _, ok := a.privateIDs[src.ID]; ok {
 		return ErrAddrBookPrivateSrc{src}
+	}
+
+	// TODO: we should track ourAddrs by ID and by IP:PORT and refuse both.
+	if _, ok := a.ourAddrs[addr.String()]; ok {
+		return ErrAddrBookSelf{addr}
+	}
+
+	if a.routabilityStrict && !addr.Routable() {
+		return ErrAddrBookNonRoutable{addr}
+	}
+
+	if !addr.Valid() {
+		return ErrAddrBookInvalidAddr{addr}
 	}
 
 	ka := a.addrLookup[addr.ID]

--- a/p2p/pex/errors.go
+++ b/p2p/pex/errors.go
@@ -11,7 +11,7 @@ type ErrAddrBookNonRoutable struct {
 }
 
 func (err ErrAddrBookNonRoutable) Error() string {
-	return fmt.Sprintf("Cannot add non-routable address %v (if it's a private network, set addr_book_strict to false in the config)", err.Addr)
+	return fmt.Sprintf("Cannot add non-routable address %v", err.Addr)
 }
 
 type ErrAddrBookSelf struct {
@@ -30,12 +30,20 @@ func (err ErrAddrBookPrivate) Error() string {
 	return fmt.Sprintf("Cannot add private peer with address %v", err.Addr)
 }
 
+func (err ErrAddrBookPrivate) PrivateAddr() bool {
+	return true
+}
+
 type ErrAddrBookPrivateSrc struct {
 	Src *p2p.NetAddress
 }
 
 func (err ErrAddrBookPrivateSrc) Error() string {
 	return fmt.Sprintf("Cannot add peer coming from private peer with address %v", err.Src)
+}
+
+func (err ErrAddrBookPrivateSrc) PrivateAddr() bool {
+	return true
 }
 
 type ErrAddrBookNilAddr struct {

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/tendermint/tendermint/config"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/p2p/conn"
@@ -396,6 +398,15 @@ func (sw *Switch) MarkPeerAsGood(peer Peer) {
 //---------------------------------------------------------------------
 // Dialing
 
+type privateAddr interface {
+	PrivateAddr() bool
+}
+
+func isPrivateAddr(err error) bool {
+	te, ok := errors.Cause(err).(privateAddr)
+	return ok && te.PrivateAddr()
+}
+
 // DialPeersAsync dials a list of peers asynchronously in random order (optionally, making them persistent).
 // Used to dial peers from config on startup or from unsafe-RPC (trusted sources).
 // TODO: remove addrBook arg since it's now set on the switch
@@ -418,7 +429,11 @@ func (sw *Switch) DialPeersAsync(addrBook AddrBook, peers []string, persistent b
 			// do not add our address or ID
 			if !netAddr.Same(ourAddr) {
 				if err := addrBook.AddAddress(netAddr, ourAddr); err != nil {
-					sw.Logger.Error("Can't add peer's address to addrbook", "err", err)
+					if isPrivateAddr(err) {
+						sw.Logger.Debug("Won't add peer's address to addrbook", "err", err)
+					} else {
+						sw.Logger.Error("Can't add peer's address to addrbook", "err", err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When we start bnbchaind, we often see following error:
```
E[2019-03-21|09:02:55.560] Can't add peer's address to addrbook         module=p2p err="Cannot add non-routable address 4390afd570366e50f13e05b592a6bc06fb77d02c@172.27.41.104:27146"
```

This is becuase `172.27.41.104` is treated as private ip, and will not be pexed, so there is no need to add to address book.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
