### PR TITLE
[R4R]p2p: do not stop peer when it seend pex message too quick

### DIFF
--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -245,7 +245,8 @@ func (r *PEXReactor) Receive(chID byte, src Peer, msgBytes []byte) {
 		} else {
 			// Check we're not receiving requests too frequently.
 			if err := r.receiveRequest(src); err != nil {
-				r.Switch.StopPeerForError(src, err)
+				// If the peer send pexrequest too quick, just ignore it. No need to stop the peer
+				r.Logger.Error(err.Error())
 				return
 			}
 			r.SendAddrs(src, r.book.GetSelection())


### PR DESCRIPTION
The normal fix will be in this pr 
https://github.com/tendermint/tendermint/pull/3361/files, still pushing on it.

And I need more e2e test and ut test about it since Qa occur the problem again, but it will take sometime to do it.

I would like merge this hot fix first to not block normal use of full node.

Actually, we can ignore the DDOS risk here, since it is very easily to send any other type of message that cost more cpu to handle it, pex request message is a bad choise for hacker. Even handshake of p2p can used for DDOS, so I think ignore the message is reasonable.

