### PR TITLE
[R4R]hotfix: security/p2p: handle nil netaddr when can't resolve host

### DIFF
--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -305,7 +305,9 @@ func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 		// FIXME: persistent peers can't be inbound right now.
 		// self-reported address for inbound persistent peers
 		addr := peer.NodeInfo().NetAddress()
-		go sw.reconnectToPeer(addr)
+		if addr != nil {
+			go sw.reconnectToPeer(addr)
+		}
 	}
 }
 
@@ -393,7 +395,10 @@ func (sw *Switch) SetAddrBook(addrBook AddrBook) {
 // like contributed to consensus.
 func (sw *Switch) MarkPeerAsGood(peer Peer) {
 	if sw.addrBook != nil {
-		sw.addrBook.MarkGood(peer.NodeInfo().NetAddress())
+		addr := peer.NodeInfo().NetAddress()
+		if addr != nil {
+			sw.addrBook.MarkGood(addr)
+		}
 	}
 }
 
@@ -552,7 +557,7 @@ func (sw *Switch) acceptRoutine() {
 		if in >= sw.config.MaxNumInboundPeers {
 			sw.Logger.Info(
 				"Ignoring inbound connection: already have enough inbound peers",
-				"address", p.NodeInfo().NetAddress().String(),
+				"address", p.NodeInfo().NetAddress(),
 				"have", in,
 				"max", sw.config.MaxNumInboundPeers,
 			)


### PR DESCRIPTION
This is a security issue, it will cause peers in network all panic , can reproduce by following step :
1. A node peer join in the p2p network, and claim its external ip as a domain name witch can be resolved.
2. After running for sometime, the owner of the peer can just disable the domain name of the peer.
3. All the other peer in the network connected to the peer will do `MarkAsGood` function, and the addr is nil and panic.

What I fixed is to handle the nil value of other peer.

Actually community already find the problem https://github.com/tendermint/tendermint/pull/3545/files
, but the pr have some previous change, can not simple cherry-pick, we could do it when upgrade tendermint. 
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
