### PR TITLE
[R4R]add OnlyPersistent to config of mempool

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -726,13 +726,14 @@ func (cfg *DBCacheConfig) ToGolevelDBOpt() *optPkg.Options {
 
 // MempoolConfig defines the configuration options for the Tendermint mempool
 type MempoolConfig struct {
-	RootDir     string `mapstructure:"home"`
-	Recheck     bool   `mapstructure:"recheck"`
-	Broadcast   bool   `mapstructure:"broadcast"`
-	WalPath     string `mapstructure:"wal_dir"`
-	Size        int    `mapstructure:"size"`
-	MaxTxsBytes int64  `mapstructure:"max_txs_bytes"`
-	CacheSize   int    `mapstructure:"cache_size"`
+	RootDir        string `mapstructure:"home"`
+	Recheck        bool   `mapstructure:"recheck"`
+	Broadcast      bool   `mapstructure:"broadcast"`
+	WalPath        string `mapstructure:"wal_dir"`
+	Size           int    `mapstructure:"size"`
+	MaxTxsBytes    int64  `mapstructure:"max_txs_bytes"`
+	CacheSize      int    `mapstructure:"cache_size"`
+	OnlyPersistent bool   `mapstructure:"only_persistent"`
 }
 
 // DefaultMempoolConfig returns a default configuration for the Tendermint mempool
@@ -743,9 +744,10 @@ func DefaultMempoolConfig() *MempoolConfig {
 		WalPath:   "",
 		// Each signature verification takes .5ms, Size reduced until we implement
 		// ABCI Recheck
-		Size:        5000,
-		MaxTxsBytes: 1024 * 1024 * 1024, // 1GB
-		CacheSize:   10000,
+		Size:           5000,
+		MaxTxsBytes:    1024 * 1024 * 1024, // 1GB
+		CacheSize:      10000,
+		OnlyPersistent: false,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -321,6 +321,9 @@ recheck = {{ .Mempool.Recheck }}
 broadcast = {{ .Mempool.Broadcast }}
 wal_dir = "{{ js .Mempool.WalPath }}"
 
+# If set true, will only broadcast transactions to persistent peers. 
+only_persistent = {{ .Mempool.OnlyPersistent }}
+
 # Maximum number of transactions in the mempool
 size = {{ .Mempool.Size }}
 

--- a/mempool/reactor.go
+++ b/mempool/reactor.go
@@ -23,7 +23,7 @@ const (
 	maxTxSize  = maxMsgSize - 8 // account for amino overhead of TxMessage
 
 	MempoolPacketChannelSize   = 1024 * 200 // 200K messages can be queued
-	peerCatchupSleepIntervalMS = 100 		// If peer is behind, sleep this amount
+	peerCatchupSleepIntervalMS = 100        // If peer is behind, sleep this amount
 
 	// UnknownPeerID is the peer ID to use when running CheckTx when there is
 	// no peer (e.g. RPC)
@@ -211,7 +211,7 @@ type PeerState interface {
 
 // Send new mempool txs to peer.
 func (memR *MempoolReactor) broadcastTxRoutine(peer p2p.Peer) {
-	if !memR.config.Broadcast {
+	if !memR.config.Broadcast || (memR.config.OnlyPersistent && !memR.Switch.IsPersistent(peer)) {
 		return
 	}
 


### PR DESCRIPTION
### Description
we want to control the direction of Transaction :
1. allow:   internet ---> core network
2. forbidden:  core network ----> internet

so that can relieve the load of full node, there are no need for them to check and recheck transaction.

What is more, we can do:
 1. forbidden:  bridge ---> dataseed/seed/witness-explorer
2. forbidden:  validator ---> bridge/witness/witness-order

also can relieve the load of node in core network.

### Rationale

The `only_persistent` can set to be true for all node in core network.
 while full node in internet shoud set to be false.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

