### PR TITLE
[R4R] introduce blockpartbit message to consensus, hard fork 

### DIFF
--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -49,8 +49,8 @@ type Metrics struct {
 	// Whether or not a node is fast syncing. 1 if yes, 0 if no.
 	FastSyncing metrics.Gauge
 
-	// Number of blockparts transmitted by peer.
-	BlockParts metrics.Counter
+	// Number of duplicate blockparts transmitted by peer.
+	DuplicateBlockParts metrics.Counter
 
 	// Number of proposals transmitted by peer.
 	Proposals metrics.Counter
@@ -158,12 +158,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "fast_syncing",
 			Help:      "Whether or not a node is fast syncing. 1 if yes, 0 if no.",
 		}, labels).With(labelsAndValues...),
-		BlockParts: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+		DuplicateBlockParts: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
-			Name:      "block_parts",
-			Help:      "Number of blockparts transmitted by peer.",
-		}, append(labels, "peer_id", "index")).With(labelsAndValues...),
+			Name:      "duplicate_block_parts",
+			Help:      "Number of duplicate blockparts transmitted by peer.",
+		}, append(labels, "peer_id")).With(labelsAndValues...),
 		Proposals: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -201,14 +201,14 @@ func NopMetrics() *Metrics {
 
 		BlockIntervalSeconds: discard.NewGauge(),
 
-		NumTxs:          discard.NewGauge(),
-		BlockSizeBytes:  discard.NewGauge(),
-		TotalTxs:        discard.NewGauge(),
-		CommittedHeight: discard.NewGauge(),
-		FastSyncing:     discard.NewGauge(),
-		BlockParts:      discard.NewCounter(),
-		Proposals:       discard.NewCounter(),
-		Votes:           discard.NewCounter(),
-		VoteSetBits:     discard.NewCounter(),
+		NumTxs:              discard.NewGauge(),
+		BlockSizeBytes:      discard.NewGauge(),
+		TotalTxs:            discard.NewGauge(),
+		CommittedHeight:     discard.NewGauge(),
+		FastSyncing:         discard.NewGauge(),
+		DuplicateBlockParts: discard.NewCounter(),
+		Proposals:           discard.NewCounter(),
+		Votes:               discard.NewCounter(),
+		VoteSetBits:         discard.NewCounter(),
 	}
 }

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1,15 +1,15 @@
 package consensus
 
 import (
+	"context"
 	"fmt"
 	"reflect"
-	"strconv"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
 
-	amino "github.com/tendermint/go-amino"
+	"github.com/tendermint/go-amino"
 	cstypes "github.com/tendermint/tendermint/consensus/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	tmevents "github.com/tendermint/tendermint/libs/events"
@@ -21,15 +21,20 @@ import (
 )
 
 const (
-	StateChannel       = byte(0x20)
-	DataChannel        = byte(0x21)
-	VoteChannel        = byte(0x22)
-	VoteSetBitsChannel = byte(0x23)
+	StateChannel         = byte(0x20)
+	DataChannel          = byte(0x21)
+	VoteChannel          = byte(0x22)
+	VoteSetBitsChannel   = byte(0x23)
+	BlockPartBitsChannel = byte(0x24)
 
 	maxMsgSize = 1048576 // 1MB; NOTE/TODO: keep in sync with types.PartSet sizes.
 
 	blocksToContributeToBecomeGoodPeer = 10000
 	votesToContributeToBecomeGoodPeer  = 10000
+
+	BlockPartSubCap = 1000
+
+	BlockPartsGossipGapMilliSecond = 500
 )
 
 //-----------------------------------------------------------------------------
@@ -153,6 +158,13 @@ func (conR *ConsensusReactor) GetChannels() []*p2p.ChannelDescriptor {
 			RecvBufferCapacity:  1024,
 			RecvMessageCapacity: maxMsgSize,
 		},
+		{
+			ID:                  BlockPartBitsChannel,
+			Priority:            10,
+			SendQueueCapacity:   100,
+			RecvBufferCapacity:  100 * 100,
+			RecvMessageCapacity: maxMsgSize,
+		},
 	}
 }
 
@@ -172,6 +184,7 @@ func (conR *ConsensusReactor) AddPeer(peer p2p.Peer) {
 	go conR.gossipDataRoutine(peer, peerState)
 	go conR.gossipVotesRoutine(peer, peerState)
 	go conR.queryMaj23Routine(peer, peerState)
+	go conR.gossipBlockPartBitsRoutine(peer, peerState)
 
 	// Send our state to peer.
 	// If we're fast_syncing, broadcast a RoundStepMessage later upon SwitchToConsensus().
@@ -292,8 +305,14 @@ func (conR *ConsensusReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) 
 			ps.ApplyProposalPOLMessage(msg)
 		case *BlockPartMessage:
 			ps.SetHasProposalBlockPart(msg.Height, msg.Round, msg.Part.Index)
-			conR.metrics.BlockParts.With("peer_id", string(src.ID())).With("index", strconv.Itoa(msg.Part.Index)).Add(1)
 			conR.conS.peerMsgQueue <- msgInfo{msg, src.ID()}
+		default:
+			conR.Logger.Error(fmt.Sprintf("Unknown message type %v", reflect.TypeOf(msg)))
+		}
+	case BlockPartBitsChannel:
+		switch msg := msg.(type) {
+		case *BlockPartBitsMessage:
+			ps.SetHasProposalBlockPart(msg.Height, msg.Round, msg.Index)
 		default:
 			conR.Logger.Error(fmt.Sprintf("Unknown message type %v", reflect.TypeOf(msg)))
 		}
@@ -464,6 +483,47 @@ func (conR *ConsensusReactor) sendNewRoundStepMessage(peer p2p.Peer) {
 	peer.Send(StateChannel, cdc.MustMarshalBinaryBare(nrsMsg))
 }
 
+func (conR *ConsensusReactor) gossipBlockPartBitsRoutine(peer p2p.Peer, ps *PeerState) {
+	logger := conR.Logger.With("peer", peer)
+	peerSubscriber := fmt.Sprintf("%s-%d", peer.ID(), time.Now().UnixNano())
+	bpSubs, err := conR.eventBus.Subscribe(context.Background(), peerSubscriber, types.EventQueryAddBlockPart, BlockPartSubCap)
+	if err != nil {
+		logger.Error("failed to subscribe AddBlockPart event", "peer", peer.ID(), "err", err)
+		conR.Switch.StopPeerForError(peer, err)
+		return
+	}
+	defer conR.eventBus.Unsubscribe(context.Background(), peerSubscriber, types.EventQueryAddBlockPart)
+	for {
+		// Manage disconnects from self or peer.
+		if !peer.IsRunning() || !conR.IsRunning() {
+			logger.Info("Stopping gossipBlockPartBitsRoutine for peer")
+			return
+		}
+		select {
+		case msg := <-bpSubs.Out():
+			partEvent := msg.Data().(types.EventDataAddBlockPart)
+			prs := ps.GetRoundState()
+			if prs.Height == partEvent.Height && prs.Round == partEvent.Round && partEvent.From != peer.ID() {
+				bz := cdc.MustMarshalBinaryBare(&BlockPartBitsMessage{partEvent.Height, partEvent.Round, partEvent.Index})
+				// sent the message as soon as possible
+				if !peer.Send(BlockPartBitsChannel, bz) {
+					logger.Error("failed to send block part bits", "peer", peer.ID())
+				}
+			}
+		case <-bpSubs.Cancelled():
+			var reason string
+			if bpSubs.Err() == nil {
+				reason = "subscriber for AddBlockPart event closed unexpectedly"
+			} else {
+				reason = bpSubs.Err().Error()
+			}
+			logger.Error(reason, "peer", peer.ID())
+			conR.Switch.StopPeerForError(peer, reason)
+			return
+		}
+	}
+}
+
 func (conR *ConsensusReactor) gossipDataRoutine(peer p2p.Peer, ps *PeerState) {
 	logger := conR.Logger.With("peer", peer)
 
@@ -490,6 +550,7 @@ OUTER_LOOP:
 				if peer.Send(DataChannel, cdc.MustMarshalBinaryBare(msg)) {
 					ps.SetHasProposalBlockPart(prs.Height, prs.Round, index)
 				}
+				time.Sleep(time.Duration(BlockPartsGossipGapMilliSecond/rs.ProposalBlockParts.BitArray().Size()) * time.Millisecond)
 				continue OUTER_LOOP
 			}
 		}
@@ -1382,6 +1443,7 @@ func RegisterConsensusMessages(cdc *amino.Codec) {
 	cdc.RegisterConcrete(&HasVoteMessage{}, "tendermint/HasVote", nil)
 	cdc.RegisterConcrete(&VoteSetMaj23Message{}, "tendermint/VoteSetMaj23", nil)
 	cdc.RegisterConcrete(&VoteSetBitsMessage{}, "tendermint/VoteSetBits", nil)
+	cdc.RegisterConcrete(&BlockPartBitsMessage{}, "tendermint/BlockPartBits", nil)
 }
 
 func decodeMsg(bz []byte) (msg ConsensusMessage, err error) {
@@ -1540,6 +1602,32 @@ func (m *BlockPartMessage) ValidateBasic() error {
 // String returns a string representation.
 func (m *BlockPartMessage) String() string {
 	return fmt.Sprintf("[BlockPart H:%v R:%v P:%v]", m.Height, m.Round, m.Part)
+}
+
+//-------------------------------------
+type BlockPartBitsMessage struct {
+	Height int64
+	Round  int
+	Index  int
+}
+
+// ValidateBasic performs basic validation.
+func (m *BlockPartBitsMessage) ValidateBasic() error {
+	if m.Height < 0 {
+		return errors.New("Negative Height")
+	}
+	if m.Round < 0 {
+		return errors.New("Negative Round")
+	}
+	if m.Index < 0 {
+		return errors.New("Negative Index")
+	}
+	return nil
+}
+
+// String returns a string representation.
+func (m *BlockPartBitsMessage) String() string {
+	return fmt.Sprintf("[BlockPartBitsMessage H:%v R:%v I:%v]", m.Height, m.Round, m.Index)
 }
 
 //-------------------------------------

--- a/node/node.go
+++ b/node/node.go
@@ -947,7 +947,7 @@ func makeNodeInfo(
 		Channels: []byte{
 			snapshot.StateSyncChannel,
 			bc.BlockchainChannel,
-			cs.StateChannel, cs.DataChannel, cs.VoteChannel, cs.VoteSetBitsChannel,
+			cs.StateChannel, cs.DataChannel, cs.VoteChannel, cs.VoteSetBitsChannel, cs.BlockPartBitsChannel,
 			mempl.MempoolChannel,
 			evidence.EvidenceChannel,
 		},

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -189,6 +189,10 @@ func (b *EventBus) PublishEventCompleteProposal(data EventDataCompleteProposal) 
 	return b.Publish(EventCompleteProposal, data)
 }
 
+func (b *EventBus) PublishAddBlockPart(data EventDataAddBlockPart) error {
+	return b.Publish(EventAddBlockPart, data)
+}
+
 func (b *EventBus) PublishEventPolka(data EventDataRoundState) error {
 	return b.Publish(EventPolka, data)
 }

--- a/types/events.go
+++ b/types/events.go
@@ -7,6 +7,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmpubsub "github.com/tendermint/tendermint/libs/pubsub"
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
+	"github.com/tendermint/tendermint/p2p"
 )
 
 // Reserved event types (alphabetically sorted).
@@ -35,6 +36,7 @@ const (
 	EventUnlock           = "Unlock"
 	EventValidBlock       = "ValidBlock"
 	EventVote             = "Vote"
+	EventAddBlockPart     = "AddBlockPart"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -110,6 +112,13 @@ type EventDataCompleteProposal struct {
 	BlockID BlockID `json:"block_id"`
 }
 
+type EventDataAddBlockPart struct {
+	Height int64  `json:"height"`
+	Round  int    `json:"round"`
+	Index  int    `json:"index"`
+	From   p2p.ID `json:"from"`
+}
+
 type EventDataVote struct {
 	Vote *Vote
 }
@@ -151,6 +160,7 @@ var (
 	EventQueryValidatorSetUpdates = QueryForEvent(EventValidatorSetUpdates)
 	EventQueryValidBlock          = QueryForEvent(EventValidBlock)
 	EventQueryVote                = QueryForEvent(EventVote)
+	EventQueryAddBlockPart        = QueryForEvent(EventAddBlockPart)
 )
 
 func EventQueryTxFor(tx Tx) tmpubsub.Query {

--- a/types/params.go
+++ b/types/params.go
@@ -11,7 +11,7 @@ const (
 	MaxBlockSizeBytes = 104857600 // 100MB
 
 	// BlockPartSizeBytes is the size of one block part.
-	BlockPartSizeBytes = 1024 * 1024 // 1MB
+	BlockPartSizeBytes = 1024 * 64 // 64KB
 
 	// MaxStateSizeBytes is the maximum permitted size of the snapshot chunk
 	// snapshot chunks:


### PR DESCRIPTION
resolve https://github.com/binance-chain/bnc-tendermint/issues/108

### Description
When running with hight TPS(10k more), the block size will increase to 5M or more, the transport volume of block part between peers are huge and redundant,  according to the test, the redundant 
rate is around 7.5(means receive a same block part 7.5 times).

This pr tries to introduce a new message `BlockPartBitsMessage`  to inform other pees that I have received a block part at hight H, round R and index I, so that peers will not send this blockpart again.

Also, the current size of the block part is 1M, this is too huge, we like to change it into 64k which is more reasonable, this will cause Hard fork.  Need to consider carefully to introduce this or not. Maybe this pr is just a candidate solution for future requirements, not merge for now.

### Rationale

According to the test, the redundant will decrease from 7.5 to 4.5 when TPS is higher than 6000.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)

### Already reviewed by

...

### Related issues
https://github.com/binance-chain/bnc-tendermint/issues/108
