### PR TITLE
[R4R]make the check before parse

### DIFF
--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	cmn "github.com/tendermint/tendermint/libs/common"
-
-	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
 	"github.com/tendermint/tendermint/state/txindex/null"
@@ -193,12 +191,7 @@ func TxSearch(ctx *rpctypes.Context, query string, prove bool, page, perPage int
 		return nil, fmt.Errorf("Transaction indexing is disabled")
 	}
 
-	q, err := tmquery.New(query)
-	if err != nil {
-		return nil, err
-	}
-
-	results, err := txIndexer.Search(q)
+	results, err := txIndexer.Search(query)
 	if err != nil {
 		return nil, err
 	}

--- a/state/txindex/indexer.go
+++ b/state/txindex/indexer.go
@@ -3,7 +3,6 @@ package txindex
 import (
 	"errors"
 
-	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -21,7 +20,7 @@ type TxIndexer interface {
 	Get(hash []byte) (*types.TxResult, error)
 
 	// Search allows you to query for transactions.
-	Search(q *query.Query) ([]*types.TxResult, error)
+	Search(q string) ([]*types.TxResult, error)
 }
 
 //----------------------------------------------------

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
-	db "github.com/tendermint/tendermint/libs/db"
+	"github.com/tendermint/tendermint/libs/db"
 
-	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/state/txindex"
 	"github.com/tendermint/tendermint/types"
 )
@@ -97,7 +96,7 @@ func TestTxSearch(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.q, func(t *testing.T) {
-			results, err := indexer.Search(query.MustParse(tc.q))
+			results, err := indexer.Search(tc.q)
 			assert.NoError(t, err)
 
 			assert.Len(t, results, tc.resultsLength)
@@ -120,7 +119,7 @@ func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
 	err := indexer.Index(txResult)
 	require.NoError(t, err)
 
-	results, err := indexer.Search(query.MustParse("account.number >= 1"))
+	results, err := indexer.Search("account.number >= 1")
 	assert.NoError(t, err)
 
 	assert.Len(t, results, 1)
@@ -173,7 +172,7 @@ func TestTxSearchMultipleTxs(t *testing.T) {
 	err = indexer.Index(txResult4)
 	require.NoError(t, err)
 
-	results, err := indexer.Search(query.MustParse("account.number >= 1"))
+	results, err := indexer.Search("account.number >= 1")
 	assert.NoError(t, err)
 
 	require.Len(t, results, 3)
@@ -191,12 +190,12 @@ func TestIndexAllTags(t *testing.T) {
 	err := indexer.Index(txResult)
 	require.NoError(t, err)
 
-	results, err := indexer.Search(query.MustParse("account.number >= 1"))
+	results, err := indexer.Search("account.number >= 1")
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, []*types.TxResult{txResult}, results)
 
-	results, err = indexer.Search(query.MustParse("account.owner = 'Ivan'"))
+	results, err = indexer.Search("account.owner = 'Ivan'")
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, []*types.TxResult{txResult}, results)
@@ -205,9 +204,9 @@ func TestIndexAllTags(t *testing.T) {
 func TestDisableRangeQuery(t *testing.T) {
 	indexer := NewTxIndex(db.NewMemDB(), IndexAllTags())
 
-	_, err := indexer.Search(query.MustParse("account.number >= 1"))
+	_, err := indexer.Search("account.number >= 1")
 	assert.Error(t, err)
-	_, err = indexer.Search(query.MustParse("account.number >= 1 AND account.sequence < 100 AND tx.height > 200 AND tx.height <= 300"))
+	_, err = indexer.Search("account.number >= 1 AND account.sequence < 100 AND tx.height > 200 AND tx.height <= 300")
 	assert.Error(t, err)
 }
 

--- a/state/txindex/null/null.go
+++ b/state/txindex/null/null.go
@@ -3,7 +3,6 @@ package null
 import (
 	"errors"
 
-	"github.com/tendermint/tendermint/libs/pubsub/query"
 	"github.com/tendermint/tendermint/state/txindex"
 	"github.com/tendermint/tendermint/types"
 )
@@ -28,6 +27,6 @@ func (txi *TxIndex) Index(result *types.TxResult) error {
 	return nil
 }
 
-func (txi *TxIndex) Search(q *query.Query) ([]*types.TxResult, error) {
+func (txi *TxIndex) Search(q string) ([]*types.TxResult, error) {
 	return []*types.TxResult{}, nil
 }


### PR DESCRIPTION
resolve issue https://github.com/binance-chain/bnc-tendermint/issues/114
### Description

more connection error between node and kafka should be taken into consideration

sarama didn't wrap tcp connection error. We need categorize them into retryable error so that downstream service cannot miss message.

### Rationale

1. for now, tx_search API may take a very long time and huge memory to execute a range query. Have a DDOS issue.
2. We would like to have an option to disable WebSocket server when someone attack our dataseed through websocket, we can shut it down and restserver still works.

### Example
```
➜  build git:(2f965c9) ✗ curl '127.0.0.1:26657/tx_search?query="tx.height>733"'
{
  "jsonrpc": "2.0",
  "id": "",
  "error": {
    "code": -32603,
    "message": "Internal error",
    "data": "range query is not supported by this node, detected invalid operators['\u003e', '\u003c', '\u003c=', '\u003e='] in the query statement"
  }
}%  
```
`\u003e` means `>`.

if disable websocket server: 
![image](https://user-images.githubusercontent.com/7310198/64529798-43c61980-d33e-11e9-9d58-c2f640cfe2aa.png)

### Changes

Code tidy up

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)


### Already reviewed by

...

### Related issues

https://github.com/binance-chain/bnc-tendermint/issues/114
