### PR TITLE
[R4R] fix tx indexer lag behind block 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,3 +19,5 @@
 ### IMPROVEMENTS:
 
 ### BUG FIXES:
+- [index] [\#129](https://github.com/binance-chain/bnc-tendermint/pull/129) fix tx indexer lag behind block
+

--- a/state/blockindex/kv/kv.go
+++ b/state/blockindex/kv/kv.go
@@ -54,6 +54,6 @@ func (bki *BlockIndex) Index(header *types.Header) error {
 	if err != nil {
 		return err
 	}
-	bki.store.Set(hash, rawBytes)
+	bki.store.SetSync(hash, rawBytes)
 	return nil
 }

--- a/state/index.go
+++ b/state/index.go
@@ -152,7 +152,7 @@ func (ih *IndexHub) SetIndexedHeight(h int64) {
 	if err != nil {
 		ih.Logger.Error("failed to MarshalBinaryBare for indexed height", "error", err, "height", h)
 	} else {
-		ih.stateDB.Set(IndexHeightKey, rawHeight)
+		ih.stateDB.SetSync(IndexHeightKey, rawHeight)
 	}
 }
 

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -111,7 +111,7 @@ func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
 		storeBatch.Set(hash, rawBytes)
 	}
 
-	storeBatch.Write()
+	storeBatch.WriteSync()
 	return nil
 }
 
@@ -141,7 +141,7 @@ func (txi *TxIndex) Index(result *types.TxResult) error {
 	}
 	b.Set(hash, rawBytes)
 
-	b.Write()
+	b.WriteSync()
 	return nil
 }
 


### PR DESCRIPTION
### Description
resolve issue https://github.com/binance-chain/bnc-tendermint/issues/128

### Rationale

The index data do not persist when block have commit.


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)

### Already reviewed by

...

### Related issues

#https://github.com/binance-chain/bnc-tendermint/issues/128

