### PR TITLE
[R4R]fix hot sync not a catched up status

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -41,6 +41,7 @@ type consensusReactor interface {
 	// for when we switch from blockchain reactor and fast sync to
 	// the consensus machine
 	SwitchToConsensus(sm.State, int)
+	SwitchToCatchUp()
 }
 
 type hotsyncReactor interface {
@@ -303,6 +304,10 @@ FOR_LOOP:
 					hotR, ok := bcR.Switch.Reactor("HOT").(hotsyncReactor)
 					if ok {
 						hotR.SwitchToHotSync(state, int32(blocksSynced))
+						conR, ok := bcR.Switch.Reactor("CONSENSUS").(consensusReactor)
+						if ok {
+							conR.SwitchToCatchUp()
+						}
 					} else {
 						// should only happen during testing
 					}

--- a/blockchain/v1/reactor.go
+++ b/blockchain/v1/reactor.go
@@ -49,6 +49,7 @@ type consensusReactor interface {
 	// for when we switch from blockchain reactor and fast sync to
 	// the consensus machine
 	SwitchToConsensus(sm.State, int)
+	SwitchToCatchUp()
 }
 
 // BlockchainReactor handles long-term catchup syncing.
@@ -496,6 +497,10 @@ func (bcR *BlockchainReactor) switchToConsensusOrHotSync() {
 		hotR, ok := bcR.Switch.Reactor("HOT").(hotsyncReactor)
 		if ok {
 			hotR.SwitchToHotSync(bcR.state, int32(bcR.blocksSynced))
+			conR, ok := bcR.Switch.Reactor("CONSENSUS").(consensusReactor)
+			if ok {
+				conR.SwitchToCatchUp()
+			}
 		} else {
 			// should only happen during testing
 		}

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -97,6 +97,13 @@ func (conR *ConsensusReactor) OnStop() {
 	}
 }
 
+func (conR *ConsensusReactor) SwitchToCatchUp() {
+	conR.mtx.Lock()
+	conR.fastSync = false
+	conR.mtx.Unlock()
+	conR.metrics.FastSyncing.Set(0)
+}
+
 // SwitchToConsensus switches from fast_sync mode to consensus mode.
 // It resets the state, turns off fast_sync, and starts the consensus state-machine
 func (conR *ConsensusReactor) SwitchToConsensus(state sm.State, blocksSynced int) {


### PR DESCRIPTION
Fix the issue that `catching_up` is still true when switch to `hot sync`.

After fix:
```
{
  "jsonrpc": "2.0",
  "id": "",
  "result": {
    "node_info": {
      "protocol_version": {
        "p2p": "7",
        "block": "10",
        "app": "0"
      },
      "id": "d522f296cba08a1bab820b6803b94b71d7dedabb",
      "listen_addr": "tcp://0.0.0.0:26659",
      "network": "bnbchain-1000",
      "version": "0.32.3",
      "channels": "36402021222330380041",
      "moniker": "testnode",
      "other": {
        "tx_index": "on",
        "rpc_address": "tcp://0.0.0.0:26667"
      }
    },
    "sync_info": {
      "latest_block_hash": "1FF42B5CDB40D77E04C6EBF1F2B7457621BB2CC3C4C6BA223F4AA3BC93E7CA58",
      "latest_app_hash": "47C73507768F6C78CC0C3158806621EE51E288DAAF6F158003A4F3C6966B1685",
      "latest_block_height": "987",
      "latest_block_time": "2020-07-13T11:55:35.364952Z",
      "catching_up": false,
      "index_height": "1043"
    },
    "validator_info": {
      "address": "82B9AC8A6D000F96BBCA4BE56355E91D79E937B7",
      "pub_key": {
        "type": "tendermint/PubKeyEd25519",
        "value": "nLSwuvGKlmULCGrq82ffYpAcPLhLa7sP838Pe2rPUGQ="
      },
      "voting_power": "0"
    }
  }
}
```