### PR TITLE
R4R: fix bug in load last validator set

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -312,9 +312,9 @@ func getBeginBlockValidatorInfo(block *types.Block, state *State, stateDB dbm.DB
 	var lastValSet *types.ValidatorSet
 	var err error
 	if block.Height > 1 {
-		// for state sync, validator set can't be load from db and it should be equal to the validator set in state
+		// for state sync, validator set can't be load from db and it should be equal to the last validator set in state
 		if block.Height == state.LastBlockHeight + 1 {
-			lastValSet = state.Validators
+			lastValSet = state.LastValidators
 		} else {
 			lastValSet, err = LoadValidators(stateDB, block.Height-1)
 			if err != nil {


### PR DESCRIPTION
Previously I made a mistake in getting last validator set for state sync. The bug will result in panic whan a new validator is created.
https://github.com/binance-chain/bnc-tendermint/blob/2f1f700e415d2978432452a67efa70fdfa4e7047/state/execution.go#L332

I have verified this change in mainnet


<!--

Thanks for filing a PR! Before hitting the button, please check the following items.
Please note that every non-trivial PR must reference an issue that explains the
changes in the PR.

-->

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
