### PR TITLE
[R4R] update go version to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tendermint/tendermint
 
-go 1.12
+go 1.16
 
 require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect


### PR DESCRIPTION
### Description

This pr updates the go version of this repo to a newer one 1.16.

### Rationale

- old go versions could have some security issues (e.g., https://github.com/golang/go/issues/38223), which also possibly affects this repo
- to align official Tendermint which uses go 1.16 (https://github.com/tendermint/tendermint/blob/master/go.mod) 

### Example

n/a

### Changes

- update go.mod file to use go 1.16


* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
