### PR TITLE
[R4R] fix infinite recursion in Secp256k1 String() method

### DIFF
--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -170,7 +170,7 @@ func (pubKey PubKeySecp256k1) Bytes() []byte {
 }
 
 func (pubKey PubKeySecp256k1) String() string {
-	return fmt.Sprintf("PubKeySecp256k1{%X}", pubKey[:])
+	return fmt.Sprintf("PubKeySecp256k1{%X}", [PubKeySecp256k1Size]byte(pubKey))
 }
 
 func (pubKey PubKeySecp256k1) Equals(other crypto.PubKey) bool {


### PR DESCRIPTION
### Description

This pr fixes a security issue of Tendermint.

### Rationale

An issue is reported and fixed in Tendermint (https://github.com/tendermint/tendermint/pull/5707), and this issue could cause infinite recursion and panic. We also need to apply the fix in this repo.

### Example

n/a

### Changes

- changed Secp256k1 String() method
