### PR TITLE
[R4R] add timeout for catch up condition check with no peers

### DIFF
--- a/blockchain/v0/pool.go
+++ b/blockchain/v0/pool.go
@@ -179,7 +179,7 @@ func (pool *BlockPool) IsCaughtUp() bool {
 	// So we add a 10 minutes timeout to prevent this case.
 	if len(pool.peers) == 0 {
 		pool.Logger.Debug("Blockpool has no peers", "duration", time.Since(pool.startTime), "height", pool.height, "initHeight", pool.initHeight)
-		if time.Since(pool.startTime) > 1*time.Minute && pool.height == pool.initHeight {
+		if time.Since(pool.startTime) > 10*time.Minute && pool.height == pool.initHeight {
 			return true
 		}
 		return false

--- a/blockchain/v0/pool.go
+++ b/blockchain/v0/pool.go
@@ -177,8 +177,11 @@ func (pool *BlockPool) IsCaughtUp() bool {
 	// There is a change that a node with the majority of voting power has no peers, it will never have changes
 	// to catch up and switch to consensus reactor, resulting in stopping the chain.
 	// So we add a 10 minutes timeout to prevent this case.
-	if len(pool.peers) == 0 && time.Since(pool.startTime) < 10*time.Minute {
-		pool.Logger.Debug("Blockpool has no peers")
+	if len(pool.peers) == 0 {
+		pool.Logger.Debug("Blockpool has no peers", "duration", time.Since(pool.startTime), "height", pool.height, "initHeight", pool.initHeight)
+		if time.Since(pool.startTime) > 1*time.Minute && pool.height == pool.initHeight {
+			return true
+		}
 		return false
 	}
 


### PR DESCRIPTION
In fast sync mode, normally it needs at least 1 peer to be considered caught up.
There is a change that a node with the majority of voting power has no peers, it will never have changes to catch up and switch to consensus reactor, resulting in stopping the chain.
So we add a 10 minutes timeout to prevent this case.

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG_PENDING.md
